### PR TITLE
Reduce CF sample data below Heroku DB limit

### DIFF
--- a/bluetail/templates/bluetail_and_silvereye_shared/base.html
+++ b/bluetail/templates/bluetail_and_silvereye_shared/base.html
@@ -34,7 +34,7 @@
       <footer class="page-footer font-small blue">
            <div class="footer-copyright text-center py-3">
              This is a demo for the open source project <a href="https://github.com/spendnetwork/silvereye/">Silvereye</a>.
-             We welcome bug reports <a href="https://github.com/spendnetwork/silvereye/issues">here.</a>.
+             We welcome bug reports <a href="https://github.com/spendnetwork/silvereye/issues">here.</a>
             </div>
       </footer>
     </div>

--- a/cove_project/settings.py
+++ b/cove_project/settings.py
@@ -150,8 +150,37 @@ STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Misc
-
-LOGGING = settings.LOGGING
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s '
+                      '%(process)d %(thread)d %(message)s'
+        },
+        'standard': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'WARNING',
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard'
+        }
+    },
+    'loggers': {
+        'django.db.backends': {
+            'level': 'ERROR',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        '': {
+            'level': 'WARNING',
+            'handlers': ['console'],
+        },
+    },
+}
 LOGGING["handlers"]["null"] = {
     "class": "logging.NullHandler",
 }

--- a/script/insert_cf_data
+++ b/script/insert_cf_data
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-script/manage get_cf_data --file_path silvereye/data/cf_daily_csv/cf_files_2019-06-01_to_2020-09-06.zip --start_date 2019-06-01 --end_date 2020-09-06 --load_data --publisher_submissions
-script/manage import_authority_types
+"$(dirname "$0")/manage" get_cf_data --file_path silvereye/data/cf_daily_csv/cf_files_2019-06-01_to_2020-09-06.zip --days 400 --load_data --publisher_submissions
+"$(dirname "$0")/manage" import_authority_types
 

--- a/script/insert_cf_data
+++ b/script/insert_cf_data
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-"$(dirname "$0")/manage" get_cf_data --file_path silvereye/data/cf_daily_csv/cf_files_2019-06-01_to_2020-09-06.zip --days 400 --load_data --publisher_submissions
+"$(dirname "$0")/manage" get_cf_data --file_path silvereye/data/cf_daily_csv/cf_files_2019-06-01_to_2020-09-06.zip --days 370 --load_data --publisher_submissions
 "$(dirname "$0")/manage" import_authority_types
 

--- a/script/setup
+++ b/script/setup
@@ -14,11 +14,8 @@ psql -d $DATABASE_URL -c "CREATE SCHEMA public"
 # Set up database.
 "$(dirname "$0")/update"
 
-# Insert sample Contracts Finder data.
-"$(dirname "$0")/insert_cf_data"
-
-# Import authority types
-"$(dirname "$0")/manage" import_authority_types
-
 # Create default superuser.
 "$(dirname "$0")/manage" shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@example.com', 'admin')"
+
+# Insert sample Contracts Finder data. (Remove this for empty deployment)
+"$(dirname "$0")/insert_cf_data"

--- a/silvereye/management/commands/get_cf_data.py
+++ b/silvereye/management/commands/get_cf_data.py
@@ -610,6 +610,7 @@ class Command(BaseCommand):
 
         parser.add_argument("--start_date", default=argparse.SUPPRESS, help="Import from date. YYYY-MM-DD")
         parser.add_argument("--end_date", default=argparse.SUPPRESS, help="Import to date. YYYY-MM-DD")
+        parser.add_argument("--days", help="Number of days before enddate to import. eg. 7")
         parser.add_argument("--file_path", type=str, help="File path to CSV data to insert.")
         parser.add_argument("--publisher_submissions", action='store_true',
                             help="Group data into publisher submissions")
@@ -631,6 +632,10 @@ class Command(BaseCommand):
 
         start_date = kwargs.get("start_date")
         end_date = kwargs.get("end_date", datetime.today().strftime("%Y-%m-%d"))
+        days = kwargs.get("days")
+        if end_date and days and not start_date:
+            start_date = end_date - relativedelta(days=days)
+
         if file_path:
             logger.info("Copying data from %s", file_path)
             if file_path.endswith(".zip"):

--- a/silvereye/management/commands/get_cf_data.py
+++ b/silvereye/management/commands/get_cf_data.py
@@ -472,7 +472,7 @@ def create_output_files(name, df, parent_directory, load_data, unflatten_contrac
                      'spend'
                      ]
     for release_type in release_types:
-        logger.info("Creating output files for %s %s", name, release_type)
+        logger.debug("Creating output files for %s %s", name, release_type)
 
         release_name = name + "-" + release_type
         output_dir = join(parent_directory, release_name)
@@ -528,7 +528,7 @@ def create_output_files(name, df, parent_directory, load_data, unflatten_contrac
 
                     # helpers.SimpleSubmissionHelpers().load_simple_csv_into_database(simple_csv_df, publisher)
                     # Load data from Simple CSV
-                    logger.info("Creating or updating Publisher %s (id %s)", publisher_name, publisher_id)
+                    logger.debug("Creating or updating Publisher %s (id %s)", publisher_name, publisher_id)
                     contact_name = df_release_type.iloc[0]["releases/0/buyer/contactPoint/name"]
                     contact_email = df_release_type.iloc[0]["releases/0/buyer/contactPoint/email"]
                     contact_telephone = df_release_type.iloc[0]["releases/0/buyer/contactPoint/telephone"]


### PR DESCRIPTION
- Add "days" arg to get_cf_data.py to limit number of days to insert
- Optimise get_cf_data.py by declaring re-usable mapper objects once only
- limit script/setup to 400 days to avoid Heroku DB row limit
- Fix duplicate logs and reduce log spam from get_cf_data.py